### PR TITLE
System: Gateways: Group - POC support for "gateway_interface" option …

### DIFF
--- a/src/opnsense/mvc/app/library/OPNsense/Firewall/Plugin.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Firewall/Plugin.php
@@ -139,14 +139,16 @@ class Plugin
                 foreach ($gwgr as $gw) {
                     if (Util::isIpAddress($gw['gwip']) && !empty($gw['int'])) {
                         $gwweight = empty($gw['weight']) ? 1 : $gw['weight'];
-                        $routeto[] = str_repeat("( {$gw['int']} {$gw['gwip']} )", $gwweight);
+                        $routeto[] = rtrim(str_repeat(" ( {$gw['int']} {$gw['gwip']} ) ,", $gwweight), ',');
                         if (strstr($gw['gwip'], ':')) {
                             $proto = 'inet6';
                         }
+                    } elseif (!empty($gw['gateway_interface']) && !empty($gw['int'])) {
+                        $routeto[] = rtrim(str_repeat(" {$gw['int']} ,", $gwweight), ',');
                     }
                 }
                 if (count($routeto) > 0) {
-                    $routetologic = "route-to {" . implode(' ', $routeto) . "}";
+                    $routetologic = "route-to {" . implode(' , ', $routeto) . "}";
                     if (!empty($gwgr[0]['poolopts'])) {
                         // Since Gateways->getGroups() returns detail items, we have no other choice than
                         // to copy top level attributes into the details if they matter (poolopts)

--- a/src/opnsense/mvc/app/library/OPNsense/Routing/Gateways.php
+++ b/src/opnsense/mvc/app/library/OPNsense/Routing/Gateways.php
@@ -541,7 +541,10 @@ class Gateways
                         }
                         // check status for all gateways in this tier
                         foreach ($tier as $gwname) {
-                            if (!empty($all_gateways[$gwname]['gateway']) && !empty($status_info[$gwname])) {
+                            if ((
+                                !empty($all_gateways[$gwname]['gateway']) && !empty($status_info[$gwname])) ||
+                                !empty($all_gateways[$gwname]['gateway_interface'])
+                            ) {
                                 $gateway = $all_gateways[$gwname];
                                 switch ($status_info[$gwname]['status']) {
                                     case 'down':
@@ -562,10 +565,25 @@ class Gateways
                                 }
                                 $gateway_item = [
                                     'int' => $gateway['if'],
-                                    'gwip' => $gateway['gateway'],
+                                    'gwip' => $gateway['gateway'] ?? '',
                                     'poolopts' => isset($gw_group->poolopts) ? (string)$gw_group->poolopts : null,
                                     'weight' => !empty($gateway['weight']) ? $gateway['weight'] : 1
                                 ];
+                                $ifipprotos = [];
+                                if (!empty($this->ifconfig[$gateway['if']])){
+                                    if (!empty($this->ifconfig[$gateway['if']]['ipv4'])) {
+                                        $ifipprotos[] ='inet';
+                                    }
+                                    if (!empty($this->ifconfig[$gateway['if']]['ipv6'])) {
+                                        $ifipprotos[] ='inet6';
+                                    }
+                                }
+                                if (
+                                    !empty($all_gateways[$gwname]['gateway_interface']) &&
+                                    in_array($gateway['ipprotocol'], $ifipprotos)
+                                ) {
+                                    $gateway_item['gateway_interface'] = '1';
+                                }
                                 $all_tiers[$tieridx][] = $gateway_item;
                                 if ($is_up) {
                                     $result[(string)$gw_group->name][] = $gateway_item;


### PR DESCRIPTION
…on groups (https://github.com/opnsense/core/issues/6486)

At the moment this doesn't look like a viable option as it's too easy to invalidate the ruleset leading to loading errors like "all pool addresses must be in the same address family". Technically it's not very difficult to push the correct options, but as <interface> <address> could be combined with <interface> alone, the validation seems to be rather complicated. Forcing the items of a group (addresses only or interfaces only) might solve some of the issues, but is quite difficult to implement knowing the different parts in play here.